### PR TITLE
fix display error in title of causalAssembly

### DIFF
--- a/_posts/2024-03-15-gobler24a.md
+++ b/_posts/2024-03-15-gobler24a.md
@@ -1,5 +1,5 @@
 ---
-title: "$\\textttcausalAssembly$: Generating Realistic Production Data for Benchmarking
+title: "$\texttt{causalAssembly}$: Generating Realistic Production Data for Benchmarking
   Causal Discovery"
 booktitle: Proceedings of the Third Conference on Causal Learning and Reasoning
 year: '2024'

--- a/_posts/2024-03-15-gobler24a.md
+++ b/_posts/2024-03-15-gobler24a.md
@@ -1,5 +1,5 @@
 ---
-title: "$\texttt{causalAssembly}$: Generating Realistic Production Data for Benchmarking
+title: "`causalAssembly`: Generating Realistic Production Data for Benchmarking
   Causal Discovery"
 booktitle: Proceedings of the Third Conference on Causal Learning and Reasoning
 year: '2024'

--- a/_posts/2024-03-15-gobler24a.md
+++ b/_posts/2024-03-15-gobler24a.md
@@ -31,7 +31,7 @@ abstract: Algorithms for causal discovery have recently undergone rapid advances
 layout: inproceedings
 issn: 2640-3498
 id: gobler24a
-tex_title: "$\\texttt{causalAssembly}$: Generating Realistic Production Data for Benchmarking
+tex_title: "$\texttt{causalAssembly}$: Generating Realistic Production Data for Benchmarking
   Causal Discovery"
 firstpage: 609
 lastpage: 642


### PR DESCRIPTION
Fixes a display error of `causalAssembly` paper

![image](https://github.com/mlresearch/v236/assets/11347180/c9379099-efed-4aa5-afcb-bd3cc0d2fcca)
