### PR TITLE
Display error, yet again

### DIFF
--- a/_posts/2024-03-15-gobler24a.md
+++ b/_posts/2024-03-15-gobler24a.md
@@ -1,5 +1,5 @@
 ---
-title: "`causalAssembly`: Generating Realistic Production Data for Benchmarking
+title: "\texttt{causalAssembly}: Generating Realistic Production Data for Benchmarking
   Causal Discovery"
 booktitle: Proceedings of the Third Conference on Causal Learning and Reasoning
 year: '2024'
@@ -31,7 +31,7 @@ abstract: Algorithms for causal discovery have recently undergone rapid advances
 layout: inproceedings
 issn: 2640-3498
 id: gobler24a
-tex_title: "$\texttt{causalAssembly}$: Generating Realistic Production Data for Benchmarking
+tex_title: "$\\texttt{causalAssembly}$: Generating Realistic Production Data for Benchmarking
   Causal Discovery"
 firstpage: 609
 lastpage: 642

--- a/_posts/2024-03-15-gobler24a.md
+++ b/_posts/2024-03-15-gobler24a.md
@@ -1,5 +1,5 @@
 ---
-title: "\texttt{causalAssembly}: Generating Realistic Production Data for Benchmarking
+title: "$\\texttt{causalAssembly}$: Generating Realistic Production Data for Benchmarking
   Causal Discovery"
 booktitle: Proceedings of the Third Conference on Causal Learning and Reasoning
 year: '2024'


### PR DESCRIPTION
Display error of `causalAssembly` paper still present - sorry!

![image](https://github.com/mlresearch/v236/assets/11347180/2d20f71e-16cc-46f4-9599-a1ee765921fa)

Also the bib-file seems to interpret '\t' as tab:
```
@InProceedings{pmlr-v236-gobler24a,
  title = 	 {$	exttt{causalAssembly}$: Generating Realistic Production Data for Benchmarking Causal Discovery},
  author =       {G\"obler, Konstantin and Windisch, Tobias and Drton, Mathias and Pychynski, Tim and Roth, Martin and Sonntag, Steffen},
```
Here is another try, which at least leads to correct rendering in markdown-view

![image](https://github.com/mlresearch/v236/assets/11347180/df60e969-8892-4998-a2db-b963018ee189)